### PR TITLE
New finding "ICMP Timestamp Request Remote Date Disclosure"

### DIFF
--- a/NMB_config.json
+++ b/NMB_config.json
@@ -11,6 +11,17 @@
                 "allowed"
             ]
         },
+        "ICMP Timestamp Request Remote Date Disclosure": {
+            "ids": [
+                "10114"
+            ],
+            "scan_type": "sudo nping -icmp -icmp-type 13 -c 1 ",
+            "parameters": "{host}",
+            "verify_words": [
+                "Timestamp reply",
+                "type=14"
+            ]
+        },
         "SNMP_Public_Checks": {
             "ids": [
                 "10264",


### PR DESCRIPTION
Finding: ICMP Timestamp Request Remote Date Disclosure
Severity: Low 
Nessus Plugin ID: 10114

Description of the finding: The remote host answers to an ICMP timestamp request. This allows an attacker to know the date that is set on the targeted machine, which may assist an unauthenticated, remote attacker in defeating time-based authentication protocols.